### PR TITLE
feat: multiple categories

### DIFF
--- a/lib/logic.js
+++ b/lib/logic.js
@@ -41,7 +41,8 @@ let logic = function(data) {
             if (postCategories == newCategories.join("_")) return data;
         } 
         tmpPost.categories = newCategories
-
+        if(this.config.auto_category.multiple)
+            tmpPost.categories = tmpPost.categories.map(category => [category]);
         // 4. process post
         postStr = front.stringify(tmpPost);
         postStr = '---\n' + postStr;


### PR DESCRIPTION
添加可选项multiple，支持多个分类，而不是子分类
**这很重要**
**可以避免多个重复的子分类出现**
最终在md文档里的Front-matter里的效果如下

```
categories:
  - - Python
  - - Project
 ```
其作用与官方文档的事例一致，从yaml语法的角度来看也是可行的
```
categories:
  - [ Python ]
  - [Project ]
```
  
关于子分类和多个分类可见官方文档
https://hexo.io/docs/front-matter.html#Categories-amp-Tags
https://hexo.io/zh-cn/docs/front-matter.html#Categories-amp-Tags